### PR TITLE
Remove unused type T

### DIFF
--- a/src/ProjectiveVectors.jl
+++ b/src/ProjectiveVectors.jl
@@ -463,7 +463,7 @@ Compute the `p`-norm of `z` for the indices in `rᵢ`.
     end
     normᵢ
 end
-@inline function _norm_range(z::PVector{<:Complex}, rᵢ::UnitRange{Int}, p::Real) where {T}
+@inline function _norm_range(z::PVector{<:Complex}, rᵢ::UnitRange{Int}, p::Real)
     sqrt(_norm_range2(z, rᵢ, p))
 end
 @inline function _norm_range2(z::PVector{T}, rᵢ::UnitRange{Int}, p::Real) where {T}


### PR DESCRIPTION
This gives precompilation warnings:
```
  1 dependency had warnings during precompilation:
┌ ProjectiveVectors [01f381cc-face-5a0a-ade9-ef63dc65d628]
│  WARNING: method definition for _norm_range at /home/blegat/.julia/packages/ProjectiveVectors/ON1g9/src/ProjectiveVectors.jl:466 declares type variable T but does not use it.
└ 
```